### PR TITLE
Updating project dependencies

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -27,7 +27,7 @@
         "elm/svg": "1.0.1 <= v < 2.0.0",
         "elm-community/maybe-extra": "5.0.0 <= v < 6.0.0",
         "elm-community/typed-svg": "5.0.0 <= v < 6.0.0",
-        "rtfeldman/elm-css": "15.1.0 <= v < 16.0.0"
+        "rtfeldman/elm-css": "17.0.5 <= v < 18.0.0"
     },
     "test-dependencies": {}
 }

--- a/example/elm.json
+++ b/example/elm.json
@@ -7,7 +7,6 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "Skinney/murmur3": "2.0.8",
             "elm/browser": "1.0.0",
             "elm/core": "1.0.0",
             "elm/html": "1.0.0",
@@ -21,7 +20,7 @@
             "elm-community/maybe-extra": "5.0.0",
             "krisajenkins/elm-exts": "28.0.0",
             "pablohirafuji/elm-markdown": "2.0.5",
-            "rtfeldman/elm-css": "15.1.0"
+            "rtfeldman/elm-css": "17.0.5"
         },
         "indirect": {
             "elm/parser": "1.1.0",
@@ -29,6 +28,7 @@
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2",
             "etaque/elm-response": "3.1.0",
+            "robinheghan/murmur3": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0",
             "rtfeldman/elm-iso8601-date-strings": "1.1.2"
         }


### PR DESCRIPTION
The LAF project has unhealty dependencies on orphaned Skinney/murmur3 which provokes problems for ELM devs building on these projects. Specifically elm-auth-demo.
The proposed patch is supposed to deal with Issue #2